### PR TITLE
Added Protocol Rewards section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For any questions, support or discussion, please [post an issue in this repo her
 - Zora Developer Tools Docs: [ourzora.github.io/zora-protocol](https://ourzora.github.io/zora-protocol)
 - Zora Protocol Github: [github.com/ourzora/zora-protocol](https://github.com/ourzora/zora-protocol)
 
+
 ## Zora Creator Track Bounties
 
 **Grand prize (1) winner - 6 ETH** our favorite project
@@ -35,6 +36,11 @@ For any questions, support or discussion, please [post an issue in this repo her
 
 To qualify for any bounty, you must build your project on the Zora Protocol. This includes our contracts, developer tools, and subgraph.
 
-### Ideas
+## Protocol Rewards for Apps
+Projects can permissionlessly plug into Zora's Protocol Rewards model and start earning rewards for driving mints in their app. [Here's how it works.](https://docs.zora.co/docs/smart-contracts/creator-tools/rewards#create-referral-reward)
+
+Teams behind Warpcast, Rainbow, Layer3 and Daylight are currently earning thousands of dollars. We would love to see your exciting project earn rewards the same way!
+
+## Ideas
 
 ![Inspiration](./jacobCast.png)


### PR DESCRIPTION
Called out protocol rewards in the readme. Did not link to Dune dashboard as that was created by the Daylight team. 